### PR TITLE
s/jars/kcl_jars for JAR_DIR

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -17,7 +17,7 @@ export BUNDLE_PATH="$cache_dir/vendor/bundle"
 mkdir -p "$BUNDLE_PATH"
 bundle install
 
-export JAR_DIR="$cache_dir/vendor/jars"
+export JAR_DIR="$cache_dir/vendor/kcl_jars"
 mkdir -p "$JAR_DIR"
 rake --rakefile $(bundle info --path aws-kcl-runner)/Rakefile download_jars
 


### PR DESCRIPTION
## Description of the change

Our go.grayscale repo expects jars to be in vendor/kcl_jars, not vendor/jars

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] Schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] All UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] The code changed/added does not introduce security vulnerabilities

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] At least one other engineer confirms that schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] At least one other engineer confirms that all UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] At least one other engineer has confirmed that the code changed/added will not introduce security vulnerabilities
- [ ] Issue from task tracker has a link to this pull request
