### PR TITLE
Update bundler version to match kcl-Gemfile.lock BUNDLED WITH

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ cache_dir="$2"
 
 export GEM_HOME="$cache_dir/vendor/gems"
 mkdir -p "$GEM_HOME"
-bundle_version="2.2.30"
+bundle_version="2.2.32"
 gem install bundler -v $bundle_version
 export PATH="$PATH:$GEM_HOME/gems/bundler-$bundle_version/exe/"
 


### PR DESCRIPTION
```
Successfully installed bundler-2.2.30

Parsing documentation for bundler-2.2.30

Done installing documentation for bundler after 2 seconds

1 gem installed

Activating bundler (2.2.32) failed:

Could not find 'bundler' (= 2.2.32) - did find: [bundler-2.4.1,bundler-2.2.30]

Checked in 'GEM_PATH=/tmp/build_f2fe5161/vendor/bundle/ruby/3.2.0:/app/.local/share/gem/ruby/3.2.0:/tmp/build_f2fe5161/vendor/ruby-3.2.0/lib/ruby/gems/3.2.0:/tmp/codon/tmp/cache/vendor/gems' , execute `gem env` for more information

To install the version of bundler this project requires, run `gem install bundler -v '2.2.32'`

 !     Push rejected, failed to compile KCL app.

 !     Push failed
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] Schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] All UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] The code changed/added does not introduce security vulnerabilities

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] At least one other engineer confirms that schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] At least one other engineer confirms that all UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] At least one other engineer has confirmed that the code changed/added will not introduce security vulnerabilities
- [ ] Issue from task tracker has a link to this pull request
