### PR TITLE
Unset BUNDLE_* after installing

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -19,7 +19,14 @@ bundle install
 
 export JAR_DIR="$cache_dir/vendor/kcl_jars"
 mkdir -p "$JAR_DIR"
-bundle exec rake --rakefile $(bundle info --path aws-kcl-runner)/Rakefile download_jars
+
+GEM_INSTALL_PATH="$(bundle info --path aws-kcl-runner)"
+
+# Ensure we use the app's enviroment and gems when running the rake command.
+unset $BUNDLE_PATH
+unset $BUNDLE_GEMFILE
+
+rake --rakefile "$GEM_INSTALL_PATH/Rakefile" download_jars
 
 echo "Copying jars to build dir"
 cp -r "$JAR_DIR" "$build_dir/vendor/"


### PR DESCRIPTION
This should hopefully prevent the rake command from loading the wrong bundle environment and failing to boot rake/the app.
